### PR TITLE
Solved Remove BST keys outside given range

### DIFF
--- a/problems/remove-bst-keys-outside-given-range/README.md
+++ b/problems/remove-bst-keys-outside-given-range/README.md
@@ -1,0 +1,26 @@
+# Remove BST keys outside given range
+
+Given the **root** of a Binary Search Tree (BST) and two integers **l** and **r**, remove all the nodes whose values lie outside the range [l, r].
+
+**Note:** The modified tree should also be BST.
+
+**Examples:**
+
+```bash
+Input: root = [6, -13, 14, N, -8, 13, 15, N, N, 7], l = -10, r = 13
+
+Output: [6, -8, 13, N, N, 7]
+Explanation: All the nodes outside the range [-10, 13] are removed and the modified tree is a valid BST.
+```
+
+```bash
+Input: root = [14, 4, 16, 2, 8, 15, N, -8, 3, 7, 10], l = 2, r = 6
+
+Output: [4, 2, N, N, 3]
+Explanation: All the nodes outside the range [2, 6] are removed and the modified tree is a valid BST.
+```
+
+**Constraints:**
+1 ≤ number of nodes ≤ 10^4
+1 ≤ node->data ≤ 10^4
+1 ≤ l ≤ r ≤ 10^4

--- a/problems/remove-bst-keys-outside-given-range/remove-bst-keys-outside-given-range.js
+++ b/problems/remove-bst-keys-outside-given-range/remove-bst-keys-outside-given-range.js
@@ -1,0 +1,35 @@
+/**
+ * @param {Node} root
+ * @param {number} l
+ * @param {number} r
+ * @return {Node}
+ */
+
+/*
+class Node {
+    constructor(x){
+        this.data=x;
+        this.left=null;
+        this.right=null;
+    }
+}
+*/
+
+class Solution {
+  removekeys(root, l, r) {
+    if (!root) return null;
+
+    if (root.data < l) {
+      return this.removekeys(root.right, l, r);
+    }
+
+    if (root.data > r) {
+      return this.removekeys(root.left, l, r);
+    }
+
+    root.left = this.removekeys(root.left, l, r);
+    root.right = this.removekeys(root.right, l, r);
+
+    return root;
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a solution to remove BST keys outside the inclusive range [l, r] and include accompanying problem documentation

New Features:
- Implement recursion-based Solution.removekeys method to prune BST nodes outside a specified range

Documentation:
- Add README with problem statement, examples, and constraints for removing BST keys outside a given range